### PR TITLE
Update ghostwriter/coding-standard to version dev-main#13ba985

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -815,12 +815,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "f3eb328a44b318208f7c5e5f65a99d9ff6670852"
+                "reference": "13ba98577d324beb77c70c05a63d75bfd3c08da9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f3eb328a44b318208f7c5e5f65a99d9ff6670852",
-                "reference": "f3eb328a44b318208f7c5e5f65a99d9ff6670852",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/13ba98577d324beb77c70c05a63d75bfd3c08da9",
+                "reference": "13ba98577d324beb77c70c05a63d75bfd3c08da9",
                 "shasum": ""
             },
             "require": {
@@ -880,7 +880,7 @@
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.2",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^12.4.4",
+                "phpunit/phpunit": "^12.4.5",
                 "symfony/process": "^8.0.0",
                 "symfony/var-dumper": "^8.0.0"
             },
@@ -996,7 +996,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-29T21:23:11+00:00"
+            "time": "2025-12-01T10:32:29+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#f3eb328` to `dev-main#13ba985`.

This pull request changes the following file(s): 

- Update `composer.lock`